### PR TITLE
Add content SFI ms.custom values

### DIFF
--- a/msal-java-articles/advanced/migrate-adal-msal-java.md
+++ b/msal-java-articles/advanced/migrate-adal-msal-java.md
@@ -3,13 +3,13 @@ title: ADAL to MSAL migration guide (MSAL4j)
 description: Learn how to migrate your Azure Active Directory Authentication Library (ADAL) Java app to the Microsoft Authentication Library (MSAL).
 author: Dickson-Mwendia
 manager: CelesteDG
-
 ms.author: dmwendia
 ms.date: 01/27/2024
-ms.reviewer:
+ms.reviewer: 
 ms.service: msal
 ms.subservice: msal-java
 ms.topic: conceptual
+ms.custom: sfi-ropc-nochange
 ---
 
 # ADAL to MSAL migration guide for Java

--- a/msal-java-articles/build/fiddler.md
+++ b/msal-java-articles/build/fiddler.md
@@ -3,14 +3,13 @@ title: Using Fiddler with MSAL Java
 description: "You can use the MSAL4J with a proxy such as Fiddler to debug requests and responses."
 author: Dickson-Mwendia
 manager: CelesteDG
-
 ms.author: dmwendia
 ms.date: 01/27/2024
-ms.reviewer:
+ms.reviewer: 
 ms.service: msal
 ms.subservice: msal-java
 ms.topic: conceptual
-
+ms.custom: sfi-ropc-nochange
 ---
 
 # Using Fiddler with MSAL Java


### PR DESCRIPTION
This pull request updates metadata in two MSAL Java documentation files to include a new custom property, `ms.custom: sfi-ropc-nochange`
Metadata updates:

* [`msal-java-articles/advanced/migrate-adal-msal-java.md`](diffhunk://#diff-95d466bdf4e42181a16d15f044468222c4011bed51e5565d8b330b50f1fa53baL6-R12): Added `ms.custom: sfi-ropc-nochange` to the metadata section.
* [`msal-java-articles/build/fiddler.md`](diffhunk://#diff-f64199102d5b4f9b3efcf763d8cd97611007397b993951705210f1933d7ea626L6-R12): Added `ms.custom: sfi-ropc-nochange` to the metadata section.