### PR TITLE
Add pull_request trigger to linkchecker workflow

### DIFF
--- a/.github/workflows/linkchecker.yml
+++ b/.github/workflows/linkchecker.yml
@@ -1,7 +1,10 @@
 name: Validate existing links
 
 on:
+  pull_request:
   push:
+    branches-ignore:
+      - live
   repository_dispatch:
   workflow_dispatch:
   schedule:


### PR DESCRIPTION
The linkchecker workflow was missing a pull_request trigger, so it never ran as a PR check. This adds the trigger so broken links are caught before merging.